### PR TITLE
fix(templates): Make apply command compatible to older TF versions

### DIFF
--- a/templates/scripts/terraform_apply_with_auto_approve
+++ b/templates/scripts/terraform_apply_with_auto_approve
@@ -8,4 +8,4 @@ terraform apply \
 terraform apply \
   ${extraArgs} \
   -auto-approve \
-  -refresh-only
+  -refresh=true


### PR DESCRIPTION
In this pull request I'm suggesting use the flag `-refresh=true` instead of `-refresh-only` so we can have this packager compatible to old versions of Terraform.