### PR TITLE
fix(build_setup_variables): choose provider credentials based on the first ocurrence

### DIFF
--- a/scripts/build_setup_variables
+++ b/scripts/build_setup_variables
@@ -52,7 +52,7 @@ fi
 
 TERRAFORM_VERSION=$( grep "^  version:" "${TF_PACKAGER_STACK_CONFIG_YAML_FILE}" | awk '{ print $2}' | tr -d " ")
 TERRAFORM_BACKEND=$( grep "^  backend:" "${TF_PACKAGER_STACK_CONFIG_YAML_FILE}" | awk '{ print $2}' | tr -d " ")
-TERRAFORM_PROVIDER=$(grep "^provider"   "${TF_PACKAGER_SOURCE_CODE_PROVIDER_FILE?}" | grep -oP '(?<=\")(.*)(?=\")')
+TERRAFORM_PROVIDER=$(grep "^provider"   "${TF_PACKAGER_SOURCE_CODE_PROVIDER_FILE?}" | grep -oP -m 1 '(?<=\")(.*)(?=\")')
 
 TERRAFORM_PROVIDER_TEMPLATE_CREDENTIALS_FILE="${TF_PACKAGER_TEMPLATES_DIRECTORY}/provider/${TERRAFORM_PROVIDER}/credentials_build.conf"
 TERRAFORM_BACKEND_TEMPLATE_CREDENTIALS_FILE="${TF_PACKAGER_TEMPLATES_DIRECTORY}/backend/${TERRAFORM_BACKEND}/credentials_build.conf"


### PR DESCRIPTION
Here I'm forcing the `build_setup_variables` script to use only the first provider of the `provider.tf` file to define the credentials that it will use on the process. Maybe it's not the best approach, but this is a workaround to a specific case where the declaration below is still demanded on the stack: 

```
provider "mongodbatlas" {}

provider "azurerm" {
  features {}
}
```

Perhaps evolve this script to load and consider the credentials of many providers is the right/generic approach. Would be a good feature.