### PR TITLE
feat(destroy-twice-command): create an alias command

### DIFF
--- a/templates/scripts/entrypoint
+++ b/templates/scripts/entrypoint
@@ -53,4 +53,9 @@ if [ -z "${terraformDefaultArgs}" ]; then
   fi
 fi
 
+if [ "${TERRAFORM_COMMAND}" == "destroy-twice" ]; then
+  terraform_destroy_twice ${terraformDefaultArgs}
+  exit $?
+fi
+
 terraform ${TERRAFORM_COMMAND} ${terraformDefaultArgs}

--- a/templates/scripts/terraform_destroy_twice
+++ b/templates/scripts/terraform_destroy_twice
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## SOMETIMES A STACK DEMANDS DESTROY TWICE IN ORDER TO
+## GET A WELL-SUCCEEDED FEEDBACK, E.G: STACKS THAT MANAGE
+## KEY-VAULT SECRETS ON A SOFT-DELETE ENABLED KEY VAULT.
+
+args="$@"
+
+terraform destroy ${args}
+
+echo ""
+echo "Retry destroy command"
+terraform destroy ${args}


### PR DESCRIPTION
Create a special command to deal with the situations when a second attempt is demanded to destroy the resources
(key-vault secrets for instance)