### PR TITLE
feat: Checking if we have files inside the extra directory

### DIFF
--- a/scripts/stackrun
+++ b/scripts/stackrun
@@ -56,11 +56,13 @@ generate_a_script_to_run_the_command() {
   cat "${TEMPLATES_FOLDER?}/stackrun.conf"
 
   if [ -e "${LOCAL_TERRAFORM_VARIABLES_DIRECTORY_EXTRA}" ]; then
-    while read FILE_NAME; do
-      BASE_FILE_NAME="$(basename "${FILE_NAME}")"
-      COMMAND_VOLUME="$(printf '"%s:/opt/src/%s"' "${FILE_NAME}" "${BASE_FILE_NAME}")"
+    files=$(find ${LOCAL_TERRAFORM_VARIABLES_DIRECTORY_EXTRA} -type f)
+    IFS=$'\n'
+    for file in ${files} ; do
+      BASE_FILE_NAME="$(basename "${file}")"
+      COMMAND_VOLUME="$(printf "\"${file}:/opt/src${file}"\" "${file}" "${BASE_FILE_NAME}")"
       echo "  -v ${COMMAND_VOLUME} \\"
-    done <<< "$(find ${LOCAL_TERRAFORM_VARIABLES_DIRECTORY_EXTRA} -type f | xargs -n 1)"
+    done
   fi
 
   if [ -n "${LOCAL_EXTRA_VOLUMES}" ]; then


### PR DESCRIPTION
We are using `terraform-packager` internally and recently Azure DevOps started to use Docker 24.0.5 on their machines used to run the builds/pipelines.

Since then we are facing an issue which is that terraform-packager's `stackrun` command tries to mount the command to be used by docker later containing the volumes to be mounted inside the container without first checking if there are files inside the directory pointed by the `LOCAL_TERRAFORM_VARIABLES_DIRECTORY_EXTRA` variable.

We found out that before version 24.0.4 there was an issue on Docker itself, which silently ignored empty values for the source directories passed to the mount option, not failing on this and going ahead silently with the issue there.

This issue was fixed on Docker version 24.0.4 as can be seen [here](https://github.com/docker/cli/pull/4423). As we are using Docker 24.0.5 now, we were hit by this issue.

We fixed it here locally and would like to propose the change to terraform-packager upstream (you). Could you please evaluate and see if this would be OK to merge ?

Thank you :-)