### PR TITLE
feat: adding runtime scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,32 @@ pip install azure-cli
 az version
 ```
 
+## Scripts para executar durante runtime
+
+Se você precisar executar scripts durante runtime, você pode criar um diretório `.tfp/scripts/runtime` na raiz do seu repositório.
+
+```bash
+.
+├── .tfp
+│   └── scripts
+│       └── runtime
+│           ├── after-apply
+│           ├── after-destroy
+│           ├── after-init
+│           ├── after-plan
+│           ├── before-apply
+│           ├── before-destroy
+│           ├── before-init
+│           └── before-plan
+├── README.md
+├── cz.yaml -> ../../cz.yaml
+├── src
+│   ├── main.tf
+│   └── provider.tf
+└── stack.yaml
+```
+
+
 ### Azure Credentials
 
 O script `stackrun' vai montar os arquivos de credenciais do Azure CLI no container caso os arquivos existam e a variável de ambiente `ARM_CLIENT_ID` esteja vazia.

--- a/examples/azure-null-resource/.tfp/scripts/runtime/after-apply
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/after-apply
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### AFTER APPLY ####"

--- a/examples/azure-null-resource/.tfp/scripts/runtime/after-destroy
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/after-destroy
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### AFTER DESTROY ####"

--- a/examples/azure-null-resource/.tfp/scripts/runtime/after-init
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/after-init
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### AFTER INIT ####"

--- a/examples/azure-null-resource/.tfp/scripts/runtime/after-plan
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/after-plan
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### AFTER PLAN ####"

--- a/examples/azure-null-resource/.tfp/scripts/runtime/before-apply
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/before-apply
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### BEFORE APPLY ####"

--- a/examples/azure-null-resource/.tfp/scripts/runtime/before-destroy
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/before-destroy
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### BEFORE DESTROY ####"

--- a/examples/azure-null-resource/.tfp/scripts/runtime/before-init
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/before-init
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### BEFORE INIT ####"

--- a/examples/azure-null-resource/.tfp/scripts/runtime/before-plan
+++ b/examples/azure-null-resource/.tfp/scripts/runtime/before-plan
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "#### BEFORE PLAN ####"

--- a/scripts/stackrun
+++ b/scripts/stackrun
@@ -118,4 +118,11 @@ if [ "${DEBUG}" -gt 1 ]; then
   awk '{ print "    " $0 }' < "${STACK_RUN_GENERATED_SCRIPT}"
 fi
 
-"${STACK_RUN_GENERATED_SCRIPT}"
+"${STACK_RUN_GENERATED_SCRIPT}" \
+| sed \
+    -e '/You may now begin working with Terraform/,/commands will detect it and remind you to do so if necessary./d' \
+    -e '/Terraform used the selected providers/,/Resource actions are indicated with the following symbols:/d' \
+    -e '/Successfully configured the backend/,/unless the backend configuration changes./d' \
+    -e '/To perform exactly these actions/,/terraform apply "\/opt\/output\/terraform.plan\"/d'
+
+exit ${PIPESTATUS[0]}

--- a/templates/scripts/entrypoint
+++ b/templates/scripts/entrypoint
@@ -47,6 +47,8 @@ runtime_extra before init
 . terraform_init
 runtime_extra after init
 
+TERRAFORM_COMMAND_NAME=$(terraform_command_name "${TERRAFORM_COMMAND} ${terraformDefaultArgs}")
+
 if [ "${TERRAFORM_COMMAND}" == "plan-no-color" ]; then
   runtime_extra before plan
   terraform_plan_no_color ${extraArgs}
@@ -57,18 +59,18 @@ fi
 
 if [ -z "${terraformDefaultArgs}" ]; then
   if [ "${TERRAFORM_COMMAND}" == "plan" ] || [ -z "${TERRAFORM_COMMAND}" ]; then
-    runtime_extra before plan
+    runtime_extra before ${TERRAFORM_COMMAND_NAME}
     terraform_plan_with_output_file ${extraArgs}
     RESULT=$?
-    runtime_extra after plan
+    runtime_extra after ${TERRAFORM_COMMAND_NAME}
     exit ${RESULT}
   fi
 
   if [ "${TERRAFORM_COMMAND}" == "apply" ]; then
-    runtime_extra before apply
+    runtime_extra before ${TERRAFORM_COMMAND_NAME}
     terraform_apply_with_auto_approve ${extraArgs}
     RESULT=$?
-    runtime_extra after apply
+    runtime_extra after ${TERRAFORM_COMMAND_NAME}
     exit ${RESULT}
   fi
 
@@ -89,8 +91,8 @@ if [ "${TERRAFORM_COMMAND}" == "destroy-twice" ]; then
   exit ${RESULT}
 fi
 
-runtime_extra before ${TERRAFORM_COMMAND}
+runtime_extra before ${TERRAFORM_COMMAND_NAME}
 terraform ${TERRAFORM_COMMAND} ${terraformDefaultArgs}
 RESULT=$?
-runtime_extra after ${TERRAFORM_COMMAND}
+runtime_extra after ${TERRAFORM_COMMAND_NAME}
 exit ${RESULT}

--- a/templates/scripts/entrypoint
+++ b/templates/scripts/entrypoint
@@ -43,33 +43,54 @@ else
   fi
 fi
 
+runtime_extra before init
 . terraform_init
+runtime_extra after init
 
 if [ "${TERRAFORM_COMMAND}" == "plan-no-color" ]; then
+  runtime_extra before plan
   terraform_plan_no_color ${extraArgs}
-  exit $?
+  RESULT=$?
+  runtime_extra after plan
+  exit ${RESULT}
 fi
 
 if [ -z "${terraformDefaultArgs}" ]; then
   if [ "${TERRAFORM_COMMAND}" == "plan" ] || [ -z "${TERRAFORM_COMMAND}" ]; then
+    runtime_extra before plan
     terraform_plan_with_output_file ${extraArgs}
-    exit $?
+    RESULT=$?
+    runtime_extra after plan
+    exit ${RESULT}
   fi
 
   if [ "${TERRAFORM_COMMAND}" == "apply" ]; then
+    runtime_extra before apply
     terraform_apply_with_auto_approve ${extraArgs}
-    exit $?
+    RESULT=$?
+    runtime_extra after apply
+    exit ${RESULT}
   fi
 
   if [ "${TERRAFORM_COMMAND}" == "apply-refresh-only" ]; then
+    runtime_extra after before-refresh-only
     terraform_apply_with_auto_approve_and_refresh_only ${extraArgs}
-    exit $?
+    RESULT=$?
+    runtime_extra after apply-refresh-only
+    exit ${RESULT}
   fi
 fi
 
 if [ "${TERRAFORM_COMMAND}" == "destroy-twice" ]; then
+  runtime_extra before destroy
   terraform_destroy_twice ${terraformDefaultArgs}
-  exit $?
+  RESULT=$?
+  runtime_extra after destroy
+  exit ${RESULT}
 fi
 
+runtime_extra before ${TERRAFORM_COMMAND}
 terraform ${TERRAFORM_COMMAND} ${terraformDefaultArgs}
+RESULT=$?
+runtime_extra after ${TERRAFORM_COMMAND}
+exit ${RESULT}

--- a/templates/scripts/runtime_extra
+++ b/templates/scripts/runtime_extra
@@ -1,0 +1,30 @@
+#!/bin/bash
+TFP_RUNTIME_SCRIPTS="/opt/scripts/tfp/runtime"
+
+EXECUTION_MOMENT=${1}
+TERRAFORM_BASE_COMMAND=${2}
+
+execution() {
+  if [ ${DEBUG-0} -gt 2 ]; then
+    echo "tfp:trigger:${EXECUTION_MOMENT}:${TERRAFORM_BASE_COMMAND}"
+  fi
+
+  if [ -e "${TFP_RUNTIME_SCRIPTS}" ]; then
+    find "${TFP_RUNTIME_SCRIPTS}" -type f -name "${EXECUTION_MOMENT}-${TERRAFORM_BASE_COMMAND}*" \
+    | while read SCRIPT_FILE_NAME; do
+        "${SCRIPT_FILE_NAME}"
+
+        CODE_EXIT="$?"
+
+        if [ "${CODE_EXIT-0}" != "0" ]; then
+          exit "${CODE_EXIT}"
+        fi
+      done
+  fi
+}
+
+if [ "${DEBUG-0}" != "0" ]; then
+  execution
+else
+  execution > /dev/null
+fi

--- a/templates/scripts/terraform_command_name
+++ b/templates/scripts/terraform_command_name
@@ -1,0 +1,14 @@
+#!/bin/bash
+COMMAND_EXPRESSION="$1"
+
+# If commmand expression has "apply" and "-destroy", then the command name is "destroy"
+if [[ "${COMMAND_EXPRESSION}" =~ "apply"    ]] && \
+   [[ "${COMMAND_EXPRESSION}" =~ "-destroy" ]]; then
+  COMMAND_NAME="destroy"
+fi
+
+if [[ -z "${COMMAND_NAME}" ]]; then
+  COMMAND_NAME=$(echo "${COMMAND_EXPRESSION}" | awk '{print $1}')
+fi
+
+echo ${COMMAND_NAME-unknown}


### PR DESCRIPTION
Executes runtime scripts if present:

```bash
.
├── .tfp
│   └── scripts
│       └── runtime
│           ├── after-apply
│           ├── after-destroy
│           ├── after-init
│           ├── after-plan
│           ├── before-apply
│           ├── before-destroy
│           ├── before-init
│           └── before-plan
├── README.md
├── cz.yaml -> ../../cz.yaml
├── src
│   ├── main.tf
│   └── provider.tf
└── stack.yaml
```