### PR TITLE
refactor: ssh configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,7 @@ Se você precisar executar scripts durante runtime, você pode criar um diretór
 └── stack.yaml
 ```
 
-
-### Azure Credentials
+## Azure Credentials
 
 O script `stackrun' vai montar os arquivos de credenciais do Azure CLI no container caso os arquivos existam e a variável de ambiente `ARM_CLIENT_ID` esteja vazia.
 
@@ -276,6 +275,29 @@ export TF_PACKAGER_AZURE_MSAL_TOKEN_CACHE_FILE="${HOME}/.azure/msal_token_cache.
 az account get-access-token > "${TF_PACKAGER_AZURE_ACCESS_TOKEN_FILE?}"
 
 stackrun azure-cli-auth-example:latest plan
+```
+
+## Configurações SSH
+
+Se você precisar configurar chaves SSH para acessar repositórios privados, você pode criar um arquivo `${HOME}./ssh/config` seguindo exemplo abaixo:
+
+```bash
+# GitHub
+Host github.com
+    HostName github.com
+    IdentityFile ~/.ssh/id_ed25519
+
+# Azure DevOps
+Host ssh.dev.azure.com
+    HostName ssh.dev.azure.com
+    IdentityFile ~/.ssh/id_rsa
+
+# Global
+Host *
+    User git
+    PubkeyAcceptedAlgorithms +ssh-rsa
+    HostkeyAlgorithms +ssh-rsa
+    StrictHostKeyChecking no
 ```
 
 ## Variáveis de Ambiente

--- a/examples/azure-network-using-module/src/main.tf
+++ b/examples/azure-network-using-module/src/main.tf
@@ -1,0 +1,36 @@
+locals {
+  virtual_network_name  = "tfp-example"
+  virtual_network_cidrs = ["10.244.0.0/14"]
+  virtual_network_subnets = [
+    { cidr = "10.246.0.0/16", name = "aks" },
+  ]
+}
+
+resource "azurerm_resource_group" "default" {
+  name     = local.virtual_network_name
+  location = "centralus"
+}
+
+module "vnet" {
+  source = "git@github.com:smsilva/azure-network.git//src/vnet?ref=3.0.6"
+
+  name                = local.virtual_network_name
+  cidrs               = local.virtual_network_cidrs
+  subnets             = local.virtual_network_subnets
+  resource_group_name = azurerm_resource_group.default.name
+
+  depends_on = [
+    azurerm_resource_group.default
+  ]
+}
+
+module "storage" {
+  source = "git@ssh.dev.azure.com:v3/smsilva/azure-platform/azure-storage-account//src?ref=development"
+
+  name           = "tfpexample"
+  resource_group = azurerm_resource_group.default
+}
+
+output "something" {
+  value = "nothing"
+}

--- a/examples/azure-network-using-module/src/provider.tf
+++ b/examples/azure-network-using-module/src/provider.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.6.0, < 2.0.0"
+
+  backend "local" {}
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.74.0, < 3.0.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/examples/azure-network-using-module/stack.yaml
+++ b/examples/azure-network-using-module/stack.yaml
@@ -1,0 +1,4 @@
+name: azure-null-resource
+terraform:
+  version: 1.9.5
+  backend: azurerm

--- a/scripts/create_build_context
+++ b/scripts/create_build_context
@@ -14,8 +14,21 @@ cp -RL "${TF_SOURCE_CODE_DIRECTORY?}" "${TF_PACKAGER_TEMPORARY_BUILD_CONTEXT_DIR
 # Copy Credentials to Download Remote Modules on Private Git Repository during the build
 cp -R "${HOME}/.ssh" "${TF_PACKAGER_TEMPORARY_BUILD_CONTEXT_DIRECTORY?}/.ssh"
 
-# Copy SSH Config File with Strict Host Checking Disabled
-cp "${TF_PACKAGER_TEMPLATES_DIRECTORY}/ssh_config" "${TF_PACKAGER_TEMPORARY_BUILD_CONTEXT_DIRECTORY?}/.ssh/config"
+# Set template and target .ssh/config files
+TFP_SSH_CONFIG_FILE_TEMPLATE="${TF_PACKAGER_TEMPLATES_DIRECTORY}/ssh_config"
+TFP_SSH_CONFIG_FILE_TARGET="${TF_PACKAGER_TEMPORARY_BUILD_CONTEXT_DIRECTORY?}/.ssh/config"
+
+# Check if config file was copied with .ssh directory
+if [ ! -e "${TFP_SSH_CONFIG_FILE_TARGET?}" ]; then
+  # Copy SSH Config File with Strict Host Checking Disabled
+  cp "${TFP_SSH_CONFIG_FILE_TEMPLATE?}" "${TFP_SSH_CONFIG_FILE_TARGET?}"
+else
+  # Check if Global Host configuration is not present
+  if ! grep --quiet "Host \*" "${TFP_SSH_CONFIG_FILE_TARGET?}"; then
+    # Add Global Host configuration
+    cat "${TFP_SSH_CONFIG_FILE_TEMPLATE?}" >> "${TFP_SSH_CONFIG_FILE_TARGET?}"
+  fi
+fi
 
 # Check if Azure Access Token exists
 TF_PACKAGER_AZURE_ACCESS_TOKEN_FILE="${TF_PACKAGER_AZURE_ACCESS_TOKEN_FILE-${HOME}/.azure/access_token.json}"


### PR DESCRIPTION
We should not override the ssh/config file. Just add the configuration from the template if it isn't present.